### PR TITLE
SPARC target fixes

### DIFF
--- a/hw/sparc64/sparc64.c
+++ b/hw/sparc64/sparc64.c
@@ -185,7 +185,6 @@ static void main_cpu_reset(void *opaque)
 {
     ResetData *s = (ResetData *)opaque;
     CPUSPARCState *env = &s->cpu->env;
-    static unsigned int nr_resets;
 
     cpu_reset(CPU(s->cpu));
 
@@ -196,12 +195,7 @@ static void main_cpu_reset(void *opaque)
     env->gregs[1] = 0; /* Memory start */
     env->gregs[2] = ram_size; /* Memory size */
     env->gregs[3] = 0; /* Machine description XXX */
-    if (nr_resets++ == 0) {
-        /* Power on reset */
-        env->pc = s->prom_addr + 0x20ULL;
-    } else {
-        env->pc = s->prom_addr + 0x40ULL;
-    }
+    env->pc = s->prom_addr + 0x20ULL; /* reset */
     env->npc = env->pc + 4;
 }
 

--- a/target/sparc/translate.c
+++ b/target/sparc/translate.c
@@ -360,6 +360,8 @@ static inline bool use_goto_tb(DisasContext *s, target_ulong pc,
 #endif
 }
 
+static void gen_exception(DisasContext *dc, int which);
+
 static inline void gen_goto_tb(DisasContext *s, int tb_num,
                                target_ulong pc, target_ulong npc)
 {
@@ -371,6 +373,9 @@ static inline void gen_goto_tb(DisasContext *s, int tb_num,
         tcg_gen_exit_tb((uintptr_t)s->tb + tb_num);
     } else {
         /* jump to another page: currently not optimized */
+        if (s->singlestep) {
+            gen_exception(s, EXCP_DEBUG);
+        }
         tcg_gen_movi_tl(cpu_pc, pc);
         tcg_gen_movi_tl(cpu_npc, npc);
         tcg_gen_exit_tb(0);


### PR DESCRIPTION
- qemu's SPARC target doesn't run on big-endian hosts because it did not use the fprs register consistently
- qemu was treating every warm reset as an eXternally-Initiated Reset, reverted
- single-stepping was completely broken and then a bit broken in that single-stepping over certain instructions would skip over two instructions instead