### PR TITLE
stack corruption in gdb_handle_packet

### DIFF
--- a/gdbstub.c
+++ b/gdbstub.c
@@ -792,7 +792,7 @@ static int gdb_handle_packet(GDBState *s, const char *line_buf)
     const char *p;
     uint32_t thread;
     int ch, reg_size, type, res;
-    char buf[MAX_PACKET_LENGTH];
+    char buf[MAX_PACKET_LENGTH + 1]; /* include space for trailing NUL */
     uint8_t mem_buf[MAX_PACKET_LENGTH];
     uint8_t *registers;
     target_ulong addr, len;


### PR DESCRIPTION
qemu was aborting due to stack corruption on OSX when using a remote
gdb to print very large structures.  The amount of memory being dumped
was limited to MAX_PACKET_SIZE/2 but memtohex() also needs to append a
trailing NUL byte for put_packet()'s strlen to work.  That extra byte
was corrupting the stack.